### PR TITLE
Use config.LOCAL_TCP_MSS instead of config.TAP_MTU-40

### DIFF
--- a/pytcp/config.py
+++ b/pytcp/config.py
@@ -136,7 +136,7 @@ EPHEMERAL_PORT_RANGE = range(32168, 60700, 2)
 TAP_MTU = 1500
 
 # TCP session related settings
-LOCAL_TCP_MSS = 1460  # Maximum segment peer can send to us
+LOCAL_TCP_MSS = TAP_MTU - 40  # Maximum segment peer can send to us
 LOCAL_TCP_WIN = (
     65535  # Maximum amount of data peer can send to us without confirmation
 )

--- a/pytcp/protocols/tcp/session.py
+++ b/pytcp/protocols/tcp/session.py
@@ -219,7 +219,7 @@ class TcpSession:
         self._rcv_una: int = 0
 
         # Maximum segment size
-        self._rcv_mss: int = config.TAP_MTU - 40
+        self._rcv_mss: int = config.LOCAL_TCP_MSS
 
         # Window size
         self._rcv_wnd: int = 65535
@@ -889,7 +889,7 @@ class TcpSession:
                     tcp_session=self,
                 )
                 # Initialize session parameters
-                self._snd_mss = min(packet_rx_md.mss, config.TAP_MTU - 40)
+                self._snd_mss = min(packet_rx_md.mss, config.LOCAL_TCP_MSS)
                 self._snd_wnd = (
                     packet_rx_md.win * self._snd_wsc
                 )  # For SYN / SYN + ACK packets this is initialized with wscale=1
@@ -939,7 +939,7 @@ class TcpSession:
             # Packet sanity check
             if packet_rx_md.ack == self._snd_nxt and not packet_rx_md.data:
                 # Initialize session parameters
-                self._snd_mss = min(packet_rx_md.mss, config.TAP_MTU - 40)
+                self._snd_mss = min(packet_rx_md.mss, config.LOCAL_TCP_MSS)
                 self._snd_wnd = (
                     packet_rx_md.win * self._snd_wsc
                 )  # For SYN / SYN + ACK packets this is initialized with wscale=1


### PR DESCRIPTION
The config.LOCAL_TCP_MSS is never used, but should be used for the TCP MSS.