### PR TITLE
ci(publish): PyPI Trusted Publishing (OIDC, tokenless)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,12 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC) — no API token. Requires a
+    # matching PyPI "trusted publisher" registered for this repo
+    # + workflow, and id-token: write so GitHub can mint the OIDC
+    # token pypi.org verifies.
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -25,6 +31,3 @@ jobs:
 
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN__PYTCP }}


### PR DESCRIPTION
## Summary
- `publish.yml`: remove `user`/`password`; add `permissions: id-token: write` → keyless **Trusted Publishing** (OIDC).
- Fixes the release-time `403 Invalid or non-existent authentication` (expired `PYPI_API_TOKEN__PYTCP`; same failure as 2.7.10).

## Required PyPI-side step (one-time, owner)
Register a Trusted Publisher at https://pypi.org/manage/project/PyTCP/settings/publishing/ :
- Owner: `ccie18643`  •  Repo: `PyTCP`  •  Workflow: `publish.yml`  •  Environment: *(leave blank)*

## After merge + PyPI config
Recreate the `v3.0.4` GitHub Release to re-fire this workflow → tokenless publish of `PyTCP 3.0.4`.

## Test plan
- [ ] PyPI trusted publisher registered
- [ ] PR merged to master
- [ ] v3.0.4 release recreated → `Publish to PyPi` run succeeds → `pip install PyTCP==3.0.4` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)